### PR TITLE
feat(knb): auto-compile (Issue #43)

### DIFF
--- a/mcp-servers/knowledge-base/src/services/__tests__/integration-auto-compile.test.ts
+++ b/mcp-servers/knowledge-base/src/services/__tests__/integration-auto-compile.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { EdgeDBClient } from '../../edgedb';
+import { ExperienceService } from '../../services/experience';
+import { setAutoCompileRunner, resetAutoCompileDebounce } from '../../compileHook';
+import { scheduleAutoCompile } from '../../compileHook';
+
+test('adding experience in EdgeDB triggers compile via auto-runner (integration)', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'knb-int-'));
+
+  // Dynamic import of compiler to avoid loader issues
+  const buildModule = await import('../../../../../scripts/build_context');
+  const compileKnowledgeBase = buildModule.compileKnowledgeBase as (kb?: string, s?: 'filesystem'|'edgedb') => Promise<void>;
+
+  // Prepare EdgeDB client and service
+  const client = new EdgeDBClient();
+  await client.connect();
+  const expService = new ExperienceService(client);
+
+  const external_id = `int-test-exp-${Date.now()}`;
+
+  // Replace the runner to call compileKnowledgeBase against our tmp dir
+  setAutoCompileRunner(async (kbRoot?: string) => {
+    await compileKnowledgeBase(tmp, 'edgedb');
+  });
+
+  // Add experience to EdgeDB
+  const created = await expService.addExperience({
+    external_id,
+    title: { en: 'Integration Test Experience' },
+    company: { en: 'Integration Co' },
+    dates: { start: '2025-01', end: '2025-12' },
+    article: { en: 'Integration test body' },
+    verification_status: 'verified',
+    last_verified: '2025-12-01',
+    tags: [],
+    skills_demonstrated: []
+  });
+
+  // Schedule auto-compile (simulating server's behavior)
+  scheduleAutoCompile();
+
+  // Wait for debounce + compile
+  await new Promise(resolve => setTimeout(resolve, 600));
+
+  const outFile = path.join(tmp, '_compiled_context.md');
+  expect(fs.existsSync(outFile)).toBeTruthy();
+
+  const out = fs.readFileSync(outFile, 'utf8');
+  expect(out).toContain(`### ${external_id}`);
+  expect(out).toContain('Integration Test Experience');
+
+  // Cleanup
+  resetAutoCompileDebounce();
+  await client.disconnect();
+});

--- a/scripts/build_context.ts
+++ b/scripts/build_context.ts
@@ -66,10 +66,72 @@ interface Certification extends BaseEntity {
 
 const CV_SYSTEM_ROOT = path.join(__dirname, '..', '..');
 
-export async function compileKnowledgeBase(knowledgeBaseRoot?: string) {
+export async function compileKnowledgeBase(knowledgeBaseRoot?: string, source: 'filesystem' | 'edgedb' = 'filesystem') {
   const KNOWLEDGE_BASE_ROOT = knowledgeBaseRoot ?? path.join(CV_SYSTEM_ROOT, 'knowledge_base');
   const OUTPUT_FILE = path.join(KNOWLEDGE_BASE_ROOT, '_compiled_context.md');
 
+  if (source === 'edgedb') {
+    // Query EdgeDB for canonical data
+    const { EdgeDBClient } = await import('../mcp-servers/knowledge-base/src/edgedb.js');
+    const client = new EdgeDBClient();
+    await client.connect();
+
+    let compiledContent = `# Compiled Professional Background\n\n`;
+    compiledContent += `This document is automatically generated from the modular knowledge base (EdgeDB).\n`;
+    compiledContent += `It serves as a consolidated context for LLM interactions.\n\n---\n\n`;
+
+    // Experiences
+    const exps: any[] = await client.query(`
+      SELECT Experience {
+        external_id,
+        title,
+        company,
+        dates,
+        article := (SELECT .article IF EXISTS .article ELSE <json>{}),
+        tags: { name, category } ORDER BY .name
+      }
+      ORDER BY .dates.` + "`start` DESC"
+    );
+
+    if (exps.length > 0) {
+      compiledContent += `## Experiences\n\n`;
+      for (const e of exps) {
+        const yamlBlock = yaml.dump({
+          id: e.external_id,
+          type: 'employment',
+          company: e.company,
+          dates: e.dates,
+          title: e.title,
+          status: e.verification_status ?? 'verified',
+          last_verified: e.last_verified ?? new Date().toISOString().slice(0,10),
+          tags: (e.tags || []).map((t: any) => `${t.name}/${t.category}`)
+        });
+        compiledContent += `### ${e.external_id}\n\n`;
+        compiledContent += "```yaml\n" + yamlBlock + "\n```\n\n";
+        if (e.article && Object.keys(e.article).length > 0) {
+          // Keep markdown body if present under 'article.en' or 'article.et'
+          const body = e.article.en ?? e.article.et ?? '';
+          if (body) {
+            compiledContent += `${body}\n\n`;
+          }
+        }
+        compiledContent += `---\n\n`;
+      }
+    }
+
+    // TODO: add Skills, Achievements, Projects, etc. from EdgeDB as needed
+
+    compiledContent = compiledContent.replace(/\n{3,}/g, '\n\n');
+    compiledContent = compiledContent.trimEnd() + '\n';
+
+    fs.writeFileSync(OUTPUT_FILE, compiledContent, 'utf8');
+    console.log(`Knowledge base compiled (EdgeDB) to ${OUTPUT_FILE}`);
+
+    await client.disconnect();
+    return;
+  }
+
+  // Default: filesystem-based compilation (existing behavior)
   let compiledContent = `# Compiled Professional Background\n\n`;
   compiledContent += `This document is automatically generated from the modular knowledge base.\n`;
   compiledContent += `It serves as a consolidated context for LLM interactions.\n\n---\n\n`;


### PR DESCRIPTION
Export compiler function compileKnowledgeBase and auto-compile runner; tests pass locally (45 tests). See Issue #43.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces EdgeDB-backed compilation and validates auto-compile flow end-to-end.
> 
> - Extends `compileKnowledgeBase` to accept `source` (`filesystem` | `edgedb`) and implement EdgeDB compilation: queries `Experience`, emits YAML + article content, and writes `_compiled_context.md`.
> - Adds vitest integration test `integration-auto-compile.test.ts` that creates an `Experience`, triggers the auto-compile runner, and asserts compiled output.
> - Preserves existing filesystem-based compilation as the default behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e3fe69035ad08c8de38fc25ef81aa571328e88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->